### PR TITLE
Error handle for missing config file, change PHP version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .ac-php-conf.json
+ticc.json

--- a/README.org
+++ b/README.org
@@ -235,3 +235,7 @@ coder rather than on a team, and it's a small project that is pretty
 manageable as-is. However, I would welcome pull requests improving all
 these things.
 
+* Requirements
+
+- At least PHP7
+- A Postgres server (version to come)

--- a/TODO.org
+++ b/TODO.org
@@ -1,0 +1,1 @@
+* TODO Add 'license' option for displaying more of GPL license

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
 
     "require": {
-        "php": ">=5.5",
-        "lstrojny/functional-php": "~1.0",
+        "php": ">=7.0",
+        "lstrojny/functional-php": "~1.2",
         "alexkazik/getopts": "1.0.0"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,13 @@
 {
     "name": "mkrauss/ticc",
+    "license": "GPLv3",
+    "type": "project",
     "description": "Transactional Iterative Changes",
     "authors": [
         {
             "name": "Matthew Krauss",
             "email": "mkrauss@nabancard.com"
-        }
+        },
     ],
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
 
     "require": {
-        "lstrojny/functional-php": "~1.2",
+        "php": ">=5.5",
+        "lstrojny/functional-php": "~1.0",
         "alexkazik/getopts": "1.0.0"
     },
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b496194003fa2e774be7a8e0a81404b2",
-    "content-hash": "b31682713d7ad83d1ea3efe1af6a4a98",
+    "hash": "81807ab9cd6e43de951264ec780c5618",
+    "content-hash": "55422155d3f34698dce46152972c7f78",
     "packages": [
         {
             "name": "alexkazik/getopts",
@@ -19,28 +19,28 @@
         },
         {
             "name": "lstrojny/functional-php",
-            "version": "1.2.0",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lstrojny/functional-php.git",
-                "reference": "36506d28c29fcfdc260c2341e251ea8834f8d8ed"
+                "reference": "dffae98dd0873aeab168246792fc0501735ef971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lstrojny/functional-php/zipball/36506d28c29fcfdc260c2341e251ea8834f8d8ed",
-                "reference": "36506d28c29fcfdc260c2341e251ea8834f8d8ed",
+                "url": "https://api.github.com/repos/lstrojny/functional-php/zipball/dffae98dd0873aeab168246792fc0501735ef971",
+                "reference": "dffae98dd0873aeab168246792fc0501735ef971",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "~4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -67,7 +67,7 @@
             "keywords": [
                 "functional"
             ],
-            "time": "2015-12-03 08:26:11"
+            "time": "2015-06-23 21:56:56"
         }
     ],
     "packages-dev": [],
@@ -76,6 +76,8 @@
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.5"
+    },
     "platform-dev": []
 }

--- a/functions/topological_sort.php
+++ b/functions/topological_sort.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace functions;
 

--- a/ticc.json
+++ b/ticc.json
@@ -1,5 +1,0 @@
-{
-    "database": {
-        "name": "ticc"
-    }
-}

--- a/ticc.json
+++ b/ticc.json
@@ -1,0 +1,5 @@
+{
+    "database": {
+        "name": "ticc"
+    }
+}

--- a/ticc.php
+++ b/ticc.php
@@ -43,6 +43,7 @@ EOT;
     // On exception, print to STDERR and leave with the thrown error code
     // Error codes:
     // 0x0f - Config file not found
+    // 0x0c - Invalid command
     // 0xff - Undefined error code
     $stderr = fopen('php://stderr', 'rw');
     fputs($stderr, 'FATAL ERROR:' . PHP_EOL);

--- a/ticc.php
+++ b/ticc.php
@@ -27,6 +27,11 @@ require_once __DIR__ . '/vendor/alexkazik/getopts/getopts.php';
 
 try {
     echo <<<EOT
+ _____ ___ ___ ___
+|_   _|_ _/ __/ __|
+  | |  | | (_| (__
+  |_| |___\___\___|
+
 Transactional Iterative Changes - Copyright (C) 2016 Matthew Krauss
 
 This program comes with ABSOLUTELY NO WARRANTY; for details type `$argv[0] license -w'.

--- a/ticc.php
+++ b/ticc.php
@@ -43,10 +43,12 @@ EOT;
     // On exception, print to STDERR and leave with the thrown error code
     // Error codes:
     // 0x0f - Config file not found
+    // 0xff - Undefined error code
     $stderr = fopen('php://stderr', 'rw');
     fputs($stderr, 'FATAL ERROR:' . PHP_EOL);
     fputs($stderr, substr($e->getMessage(), 0, 1022) . PHP_EOL . PHP_EOL, 1024);
     fclose($stderr);
 
-    exit($e->getCode());
+    $code = $e->getCode() > 0 ? $e->getCode() : 0xff;
+    exit($code);
 }

--- a/ticc.php
+++ b/ticc.php
@@ -1,18 +1,48 @@
 #!/usr/bin/env php
 <?php
-
-/*
- * Transactional Iterative Changes
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
  */
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/vendor/alexkazik/getopts/getopts.php';
 
 try {
+    echo <<<EOT
+Transactional Iterative Changes - Copyright (C) 2016 Matthew Krauss
+
+This program comes with ABSOLUTELY NO WARRANTY; for details type `$argv[0] license -w'.
+This is free software, and you are welcome to redistribute it
+under certain conditions; type `$argv[0] license -c' for details.
+
+
+
+
+
+EOT;
     (new \ticc\Ticc ($argv))->run();
 } catch (\Exception $e) {
     // On exception, print to STDERR and leave with the thrown error code
     $stderr = fopen('php://stderr', 'rw');
+    fputs($stderr, 'FATAL ERROR:' . PHP_EOL);
     fputs($stderr, substr($e->getMessage(), 0, 1022) . PHP_EOL . PHP_EOL, 1024);
     fclose($stderr);
 

--- a/ticc.php
+++ b/ticc.php
@@ -8,4 +8,13 @@
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/vendor/alexkazik/getopts/getopts.php';
 
-(new \ticc\Ticc ($argv))->run();
+try {
+    (new \ticc\Ticc ($argv))->run();
+} catch (\Exception $e) {
+    // On exception, print to STDERR and leave with the thrown error code
+    $stderr = fopen('php://stderr', 'rw');
+    fputs($stderr, substr($e->getMessage(), 0, 1022) . PHP_EOL . PHP_EOL, 1024);
+    fclose($stderr);
+
+    exit($e->getCode());
+}

--- a/ticc.php
+++ b/ticc.php
@@ -41,6 +41,8 @@ EOT;
     (new \ticc\Ticc ($argv))->run();
 } catch (\Exception $e) {
     // On exception, print to STDERR and leave with the thrown error code
+    // Error codes:
+    // 0x0f - Config file not found
     $stderr = fopen('php://stderr', 'rw');
     fputs($stderr, 'FATAL ERROR:' . PHP_EOL);
     fputs($stderr, substr($e->getMessage(), 0, 1022) . PHP_EOL . PHP_EOL, 1024);

--- a/ticc.sample.json
+++ b/ticc.sample.json
@@ -1,0 +1,5 @@
+{
+    "database": {
+        "name": "my_database"
+    }
+}

--- a/ticc.sample.json
+++ b/ticc.sample.json
@@ -1,5 +1,7 @@
 {
     "database": {
         "name": "my_database"
-    }
+    },
+
+    "plan_directory": "test-plan"
 }

--- a/ticc/Change.php
+++ b/ticc/Change.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc;
 

--- a/ticc/Database.php
+++ b/ticc/Database.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc;
 
@@ -200,7 +221,7 @@ class Database {
 
     public function unmark_deployed($change_name) {
         /*
-         * Remove the deployment info for the given chnage 
+         * Remove the deployment info for the given chnage
          */
         try {
             $this->database->exec("
@@ -335,7 +356,7 @@ class Database {
                   , verify text
                   , revert text);");});}
 
-    
+
     private $database;
     private $schema;
     private $savepoint_count;

--- a/ticc/Plan.php
+++ b/ticc/Plan.php
@@ -177,6 +177,7 @@ class Plan {
         /*
          * Get all plan files under $change_dirname
          */
+
         $change_plan = [
             'change_name' => trim($change_dirname, '/'),
             'dependencies' => $implicit_dependencies];

--- a/ticc/Plan.php
+++ b/ticc/Plan.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc;
 

--- a/ticc/Ticc.php
+++ b/ticc/Ticc.php
@@ -106,7 +106,7 @@ class Ticc {
             case 'sync': $this->run_sync(); break;
             case 'redeploy': $this->run_redeploy(); break;
             default: throw new exception\BadCommandException(
-                'Must give valid command');}}
+                'Must give valid command: [overview|deploy|revert|sync|redeploy]', 0x0c);}}
 
 
     private function run_overview() {

--- a/ticc/Ticc.php
+++ b/ticc/Ticc.php
@@ -48,7 +48,13 @@ class Ticc {
         /*
          * Load the configuration file
          */
-        
+        if (!file_exists(F\pick($this->params, 'config file', 'ticc.json'))) {
+            throw new \Exception(
+                'Please copy ticc.sample.json to ticc.json and customize as directed in the README.',
+                0x0f
+            );
+        }
+
         $this->config = json_decode(
             file_get_contents(
                 F\pick($this->params, 'config file', 'ticc.json')), true);}

--- a/ticc/Ticc.php
+++ b/ticc/Ticc.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc;
 

--- a/ticc/exception/BadChangeException.php
+++ b/ticc/exception/BadChangeException.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 

--- a/ticc/exception/BadCommandException.php
+++ b/ticc/exception/BadCommandException.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 

--- a/ticc/exception/CancelTransaction.php
+++ b/ticc/exception/CancelTransaction.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 

--- a/ticc/exception/ChangeDeploymentError.php
+++ b/ticc/exception/ChangeDeploymentError.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 

--- a/ticc/exception/FailureToMarkChange.php
+++ b/ticc/exception/FailureToMarkChange.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 

--- a/ticc/exception/NoDatabaseException.php
+++ b/ticc/exception/NoDatabaseException.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 

--- a/ticc/exception/TransactionError.php
+++ b/ticc/exception/TransactionError.php
@@ -1,4 +1,25 @@
 <?php
+/**
+ * Transactional Iterative Changes - Manage database changes
+ *
+ * Copyright (C) 2016 Matthew Krauss
+ * Copyright (C) 2016 Matthew Carter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Report issues at: https://github.com/mkrauss/ticc
+ */
 
 namespace ticc\exception;
 


### PR DESCRIPTION
Functional 1.0 can use PHP 5.5.9, while 1.1+ requires 5.6 and above 
